### PR TITLE
Persist playback volume and add output gain setting

### DIFF
--- a/main.py
+++ b/main.py
@@ -29,6 +29,8 @@ DEFAULT_SETTINGS = {
     "device_name": "Steam Deck",
     "bitrate": 320,
     "spotify_client_id": "",
+    "volume": 50,
+    "output_gain": 100,
 }
 
 # PulseAudio socket for root processes (deck user UID 1000)
@@ -206,7 +208,8 @@ class Plugin:
     _token_refresh_lock: asyncio.Lock | None = None
     # Crash auto-restart state
     _crash_timestamps: list = []
-    _pa_volume_boosted: bool = False
+    _pa_sink_input_id: str | None = None
+    _applied_output_gain: int | None = None
     _stable_start: float = 0
 
     # ── Lifecycle ──────────────────────────────────────────────
@@ -279,6 +282,7 @@ class Plugin:
             "--name", settings.get("device_name", "Steam Deck"),
             "--device-type", "computer",
             "--bitrate", str(settings.get("bitrate", 320)),
+            "--initial-volume", str(settings.get("volume", 50)),
             "--backend", "pulseaudio",
             "--system-cache", CACHE_DIR,
         ]
@@ -301,7 +305,8 @@ class Plugin:
             return {"ok": False, "error": msg}
 
         self._last_event = None
-        self._pa_volume_boosted = False
+        self._pa_sink_input_id = None
+        self._applied_output_gain = None
         self._write_pid(self._process.pid)
         self._start_monitor()
         await decky.emit("librespot_status", {"running": True, "error": None})
@@ -324,13 +329,14 @@ class Plugin:
             "running": running,
             "binary_found": os.path.isfile(LIBRESPOT_BIN),
             "settings": {k: v for k, v in self._settings.items()
-                         if k in ("device_name", "bitrate", "spotify_client_id")},
+                          if k in ("device_name", "bitrate", "spotify_client_id", "volume", "output_gain")},
             "last_event": self._last_event,
             "track_meta": self._track_meta,
             "active_device": self._active_device,
             "is_playing": is_playing,
             "position_ms": position_ms,
             "duration_ms": duration_ms,
+            "volume": self._poll_volume,
         }
 
     async def get_settings(self) -> dict:
@@ -339,9 +345,23 @@ class Plugin:
     async def set_setting(self, key: str, value) -> dict:
         if key not in DEFAULT_SETTINGS:
             return {"ok": False, "error": f"unknown setting: {key}"}
+        if key == "volume":
+            try:
+                value = max(0, min(100, int(value)))
+            except (TypeError, ValueError):
+                return {"ok": False, "error": "volume must be between 0 and 100"}
+        elif key == "output_gain":
+            try:
+                value = int(value)
+            except (TypeError, ValueError):
+                return {"ok": False, "error": "output_gain must be between 50 and 150"}
+            if not 50 <= value <= 150:
+                return {"ok": False, "error": "output_gain must be between 50 and 150"}
         self._settings[key] = value
         _save_settings(self._settings)
         decky.logger.info("Setting updated: %s = %s", key, value)
+        if key == "output_gain" and self._process and self._process.poll() is None:
+            await self._apply_output_gain()
         return {"ok": True, "settings": dict(self._settings)}
 
     # ── Playback control callable methods ────────────────────────
@@ -410,6 +430,9 @@ class Plugin:
                 _spotify_api_request, "me/player/volume", token, "PUT",
                 {"volume_percent": volume_percent},
             )
+            self._poll_volume = volume_percent
+            self._settings["volume"] = volume_percent
+            _save_settings(self._settings)
             return {"ok": True}
         except urllib.error.HTTPError as e:
             if e.code == 404:
@@ -1414,11 +1437,12 @@ class Plugin:
 
         return True
 
-    async def _boost_pa_volume(self):
-        """Set librespot's PulseAudio sink-input to 150% for audible volume."""
+    async def _apply_output_gain(self):
+        """Apply the configured gain once per librespot sink-input and value."""
         if not self._process:
             return
         pid = self._process.pid
+        output_gain = self._settings.get("output_gain", 100)
         try:
             env = os.environ.copy()
             env["PULSE_SERVER"] = PULSE_SERVER
@@ -1439,19 +1463,36 @@ class Plugin:
                 elif "application.process.id" in line and f'"{pid}"' in line:
                     sink_input_id = current_id
                     break
-            if sink_input_id:
+            if not sink_input_id:
+                self._pa_sink_input_id = None
+                self._applied_output_gain = None
+                return
 
-                def _set_vol():
-                    return subprocess.run(
-                        ["pactl", "set-sink-input-volume", sink_input_id, "150%"],
-                        capture_output=True, text=True, env=env,
-                    )
+            if (
+                sink_input_id == self._pa_sink_input_id
+                and output_gain == self._applied_output_gain
+            ):
+                return
 
-                await _exec(_set_vol)
-                decky.logger.info("PA volume boosted to 150%% for sink-input %s", sink_input_id)
-                self._pa_volume_boosted = True
+            def _set_vol():
+                return subprocess.run(
+                    ["pactl", "set-sink-input-volume", sink_input_id, f"{output_gain}%"],
+                    capture_output=True, text=True, env=env,
+                )
+
+            set_result = await _exec(_set_vol)
+            if set_result.returncode != 0:
+                decky.logger.warning(
+                    "Failed to apply output gain: %s", set_result.stderr.strip(),
+                )
+                return
+            self._pa_sink_input_id = sink_input_id
+            self._applied_output_gain = output_gain
+            decky.logger.info(
+                "Output gain set to %d%% for sink-input %s", output_gain, sink_input_id,
+            )
         except Exception as e:
-            decky.logger.warning("Failed to boost PA volume: %s", e)
+            decky.logger.warning("Failed to apply output gain: %s", e)
 
     async def _monitor_process(self):
         """Monitor librespot process health and detect system sleep/wake."""
@@ -1523,8 +1564,8 @@ class Plugin:
                         })
                         break
 
-                if not self._pa_volume_boosted:
-                    await self._boost_pa_volume()
+                if self._applied_output_gain != self._settings.get("output_gain", 100):
+                    await self._apply_output_gain()
 
                 await asyncio.sleep(3)
         except asyncio.CancelledError:

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -33,6 +33,7 @@ const backendGetStatus = callable<[], {
   is_playing: boolean;
   position_ms: number;
   duration_ms: number;
+  volume: number | null;
 }>("get_status");
 const backendSetSetting = callable<[string, any], { ok: boolean; settings?: Settings }>("set_setting");
 const backendStartOAuth = callable<[], { ok: boolean; landing_url?: string; redirect_uri?: string; error?: string }>("start_oauth");
@@ -48,6 +49,8 @@ interface Settings {
   device_name: string;
   bitrate: number;
   spotify_client_id: string;
+  volume: number;
+  output_gain: number;
 }
 
 interface LibrespotEvent {
@@ -117,6 +120,8 @@ const Content: FC = () => {
     device_name: "Steam Deck",
     bitrate: 320,
     spotify_client_id: "",
+    volume: 50,
+    output_gain: 100,
   });
   const [toggling, setToggling] = useState(false);
   const [authenticated, setAuthenticated] = useState(false);
@@ -147,6 +152,9 @@ const Content: FC = () => {
       }
       if (status.is_playing) {
         setIsPlaying(true);
+      }
+      if (status.volume != null) {
+        setVolume(status.volume);
       }
     });
     backendGetAuthStatus().then((s) => {
@@ -565,6 +573,20 @@ const handleToggle = useCallback(async (checked: boolean) => {
             rgOptions={BITRATE_OPTIONS}
             selectedOption={settings.bitrate}
             onChange={(opt) => handleSettingChange("bitrate", opt.data)}
+          />
+        </PanelSectionRow>
+
+        <PanelSectionRow>
+          <SliderField
+            label="Output gain"
+            description="Adjusts Deckify relative to game audio. Spotify volume uses the player slider."
+            value={settings.output_gain}
+            min={50}
+            max={150}
+            step={5}
+            showValue
+            valueSuffix="%"
+            onChange={(value) => handleSettingChange("output_gain", value)}
           />
         </PanelSectionRow>
 

--- a/tests/test_audio_settings.py
+++ b/tests/test_audio_settings.py
@@ -1,0 +1,109 @@
+import asyncio
+import importlib
+import logging
+import os
+import sys
+import tempfile
+import types
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+class AudioSettingsTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.tempdir = tempfile.TemporaryDirectory()
+        cls.previous_decky = sys.modules.get("decky")
+        decky = types.ModuleType("decky")
+        decky.DECKY_PLUGIN_SETTINGS_DIR = cls.tempdir.name
+        decky.DECKY_PLUGIN_RUNTIME_DIR = cls.tempdir.name
+        decky.DECKY_PLUGIN_DIR = cls.tempdir.name
+        decky.DECKY_USER_HOME = cls.tempdir.name
+        decky.DECKY_HOME = cls.tempdir.name
+        decky.logger = logging.getLogger("deckify-tests")
+        decky.emit = AsyncMock()
+        decky.migrate_logs = MagicMock()
+        decky.migrate_settings = MagicMock()
+        decky.migrate_runtime = MagicMock()
+        sys.modules["decky"] = decky
+        cls.main = importlib.import_module("main")
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls.previous_decky is None:
+            sys.modules.pop("decky", None)
+        else:
+            sys.modules["decky"] = cls.previous_decky
+        cls.tempdir.cleanup()
+
+    def setUp(self):
+        self.plugin = self.main.Plugin()
+        self.plugin._settings = dict(self.main.DEFAULT_SETTINGS)
+        self.plugin._poll_volume = None
+        self.plugin._pa_sink_input_id = None
+        self.plugin._applied_output_gain = None
+
+    def run_async(self, coroutine):
+        return asyncio.run(coroutine)
+
+    def test_set_volume_persists_only_after_spotify_accepts_it(self):
+        self.plugin._ensure_token = AsyncMock(return_value="token")
+
+        with patch.object(self.main, "_exec", AsyncMock(return_value=None)), patch.object(self.main, "_save_settings") as save:
+            result = self.run_async(self.plugin.set_volume(23))
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(self.plugin._poll_volume, 23)
+        self.assertEqual(self.plugin._settings["volume"], 23)
+        save.assert_called_once()
+
+        with patch.object(self.main, "_exec", AsyncMock(side_effect=RuntimeError("rejected"))), patch.object(self.main, "_save_settings") as save:
+            result = self.run_async(self.plugin.set_volume(31))
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(self.plugin._settings["volume"], 23)
+        save.assert_not_called()
+
+    def test_start_librespot_passes_persisted_initial_volume(self):
+        self.plugin._settings["volume"] = 23
+        process = MagicMock(pid=321)
+        process.poll.return_value = None
+
+        with patch.object(os.path, "isfile", return_value=True), patch.object(self.main.subprocess, "Popen", return_value=process) as popen, patch.object(self.plugin, "_write_pid"), patch.object(self.plugin, "_start_monitor"):
+            result = self.run_async(self.plugin.start_librespot())
+
+        command = popen.call_args.args[0]
+        volume_index = command.index("--initial-volume")
+        self.assertEqual(command[volume_index + 1], "23")
+        self.assertTrue(result["ok"])
+
+    def test_output_gain_resets_existing_stream_to_default(self):
+        self.plugin._process = MagicMock(pid=123)
+        list_result = MagicMock(returncode=0, stdout='Sink Input #42\napplication.process.id = "123"\n', stderr="")
+        set_result = MagicMock(returncode=0, stdout="", stderr="")
+
+        async def execute(function, *args, **kwargs):
+            return function(*args)
+
+        with patch.object(self.main, "_exec", side_effect=execute), patch.object(self.main.subprocess, "run", side_effect=[list_result, set_result]) as run:
+            self.run_async(self.plugin._apply_output_gain())
+
+        self.assertEqual(run.call_args_list[1].args[0][-1], "100%")
+        self.assertEqual(self.plugin._applied_output_gain, 100)
+
+    def test_runtime_output_gain_change_persists_and_applies(self):
+        self.plugin._process = MagicMock()
+        self.plugin._process.poll.return_value = None
+        self.plugin._apply_output_gain = AsyncMock()
+
+        with patch.object(self.main, "_save_settings") as save:
+            result = self.run_async(self.plugin.set_setting("output_gain", 125))
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(self.plugin._settings["output_gain"], 125)
+        save.assert_called_once()
+        self.plugin._apply_output_gain.assert_awaited_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- save the Spotify playback volume and restore it when librespot starts
- replace the fixed 150% PulseAudio boost with a configurable output gain
- add an Output gain slider to the plugin settings
- add backend tests for volume persistence and output gain

## Testing

- tested on Steam Deck
- `python -m unittest discover -s tests -p 'test_*.py'`\n- `pnpm typecheck`\n- `pnpm lint`\n- `pnpm build`